### PR TITLE
fix: minor fix to get default year

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,33 +1,42 @@
 # Built-in
+import logging
 from datetime import datetime
 
 # External
 import fastf1
 
 
+logger = logging.getLogger(__name__)
+
+BACKSTOP = 1954
+
+
 def get_default_year() -> int:
     """Get the default year for the app.
 
-    NOTE - The default year is defined as the year which has data for at least 1 race session.
+    NOTE - The default year is defined as the latest year which has data for at least 1 race session.
     """
 
-    current_year = datetime.today().year
-    event_schedule = fastf1.get_event_schedule(current_year, include_testing=False)
+    default_year = datetime.today().year
 
-    if len(event_schedule) == 0:
-        # if no data is found, return previous year
-        return current_year - 1
-
-    try:
-        # extract first race's round number.
-        # per current (2023-01-22) fastf1/ergast implementation, the value is 1.
-        race_event_round_number = event_schedule.iloc[0]["RoundNumber"]
-        # create a fastf1.core.Session object
-        first_race_event_session_obj = fastf1.get_session(current_year, race_event_round_number, "Race")
-        # load session data
-        first_race_event_session_obj.load()
-    except (ValueError, KeyError):
-        # capture errors occurred during extracting first race's round number and loading the session data
-        return current_year - 1
-
-    return current_year
+    while default_year >= BACKSTOP:
+        event_schedule = fastf1.get_event_schedule(default_year, include_testing=False)
+        if len(event_schedule) == 0:
+            # if no data is found, check previous year
+            default_year -= 1
+            continue
+        try:
+            # extract first race's round number.
+            # per current (2023-01-22) fastf1/ergast implementation, the value is 1.
+            race_event_round_number = event_schedule.iloc[0]["RoundNumber"]
+            # create a fastf1.core.Session object
+            first_race_event_session_obj = fastf1.get_session(default_year, race_event_round_number, "Race")
+            # load session data
+            first_race_event_session_obj.load()
+        except (ValueError, KeyError) as ex:
+            # capture errors occurred during extracting first race's round number and loading the session data
+            logger.exception(ex)
+            default_year -= 1
+        else:
+            return default_year
+    raise ValueError(f"No data found for years upto {BACKSTOP}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+# Built-in
+from datetime import datetime
+from unittest import TestCase, mock
+
+# External
+import pandas as pd
+
+# Project
+from app.utils import get_default_year
+
+
+class TestUtilDefaultYear(TestCase):
+
+    def setUp(self) -> None:
+        self.fake_event_schedule = pd.DataFrame.from_records([{"RoundNumber": 1}])
+
+    def test_success(self):
+        current_year = datetime.today().year
+        mock_call_get_session_load = mock.MagicMock()
+        with (
+            mock.patch(
+                "app.utils.fastf1.get_event_schedule", return_value=self.fake_event_schedule
+            ) as _mock_get_event_schedule,
+            mock.patch("app.utils.fastf1.get_session", return_value=mock_call_get_session_load) as _mock_get_session,
+        ):
+            self.assertEqual(get_default_year(), current_year)
+            _mock_get_event_schedule.assert_called_once_with(current_year, include_testing=False)
+            _mock_get_session.assert_called_once_with(current_year, 1, "Race")


### PR DESCRIPTION


Updated logic so that the default year no longer assumes last year had an F1 session.

This currently isn't a problem since there are Formula 1 sessions every year. The new function uses a more "correct" logic where it validates:
1. The year returned has an event schedule.
2. The year returned has atleast one race event in their schedule.